### PR TITLE
feat(examples): correct cluster example

### DIFF
--- a/examples/resources/camunda_cluster/resource.tf
+++ b/examples/resources/camunda_cluster/resource.tf
@@ -5,12 +5,12 @@ data "camunda_channel" "alpha" {
 
 # A cluster plan type for default trials.
 data "camunda_cluster_plan_type" "trial" {
-  name = "Trial Package"
+  name = "Trial Cluster"
 }
 
 # The region associated with the trial plan.
-data "camunda_region" "trial" {
-  name = data.camunda_cluster_plan_type.trial.region_name
+data "camunda_region" "europe" {
+  name = "Belgium, Europe (europe-west1)"
 }
 
 resource "camunda_cluster" "test" {
@@ -18,6 +18,6 @@ resource "camunda_cluster" "test" {
 
   channel    = data.camunda_channel.alpha.id
   generation = data.camunda_channel.alpha.default_generation_id
-  region     = data.camunda_region.trial.id
+  region     = data.camunda_region.europe.id
   plan_type  = data.camunda_cluster_plan_type.trial.id
 }


### PR DESCRIPTION
- fixes naming of data of the resources.


Side question: Why does my syntax highlighting not work for the default generation id?

<img width="594" alt="image" src="https://user-images.githubusercontent.com/8970764/234396333-427840f1-ecb8-4a7b-9a35-30e7a6990482.png">
