### PR TITLE
Don't fail if the managed resources don't exist anymore

### DIFF
--- a/internal/provider/camunda_cluster_connector_secret_resource.go
+++ b/internal/provider/camunda_cluster_connector_secret_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -147,7 +148,12 @@ func (r *CamundaClusterConnectorSecretResource) Read(ctx context.Context, req re
 
 	ctx = context.WithValue(ctx, console.ContextAccessToken, r.provider.accessToken)
 
-	secrets, _, err := r.provider.client.ClustersApi.GetSecrets(ctx, data.ClusterId.ValueString()).Execute()
+	secrets, response, err := r.provider.client.ClustersApi.GetSecrets(ctx, data.ClusterId.ValueString()).Execute()
+	if err != nil && response.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Connector Secret Error",

--- a/internal/provider/camunda_cluster_resource.go
+++ b/internal/provider/camunda_cluster_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -194,7 +195,12 @@ func (r *CamundaClusterResource) Read(ctx context.Context, req resource.ReadRequ
 
 	ctx = context.WithValue(ctx, console.ContextAccessToken, r.provider.accessToken)
 
-	cluster, _, err := r.provider.client.ClustersApi.GetCluster(ctx, data.Id.ValueString()).Execute()
+	cluster, response, err := r.provider.client.ClustersApi.GetCluster(ctx, data.Id.ValueString()).Execute()
+	if err != nil && response.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Client Error",


### PR DESCRIPTION
This prevents the provider from stopping early with an error message if a resource it created before has been removed out of band.

Closes: #87 