### PR TITLE
Wait for the actual cluster status to be "healthy" when creating a new cluster

### DIFF
--- a/internal/provider/camunda_cluster_resource.go
+++ b/internal/provider/camunda_cluster_resource.go
@@ -164,7 +164,12 @@ func (r *CamundaClusterResource) Create(ctx context.Context, req resource.Create
 				return nil, "", err
 			}
 
-			return cluster, string(console.CLUSTERCOMPONENTSTATUS_HEALTHY), nil
+			tflog.Info(ctx, "Camunda cluster status", map[string]interface{}{
+				"clusterID":     cluster.Uuid,
+				"clusterStatus": cluster.Status.Ready,
+			})
+
+			return cluster, string(cluster.Status.Ready), nil
 		},
 
 		Timeout:    30 * time.Minute,


### PR DESCRIPTION
Bug introduced in #105