### PR TITLE
renovate: run "go mod tidy" after updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,6 @@
 {
-  "extends": [
-    "config:base",
-  ],
+  "extends": ["config:base"],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       // Automerge minor releases


### PR DESCRIPTION
This should (?) fix the broken updates when a Go library update is proposed.